### PR TITLE
Fix status website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ With [Upptime](https://upptime.js.org), you can get your own unlimited and free 
 
 <!--end: status pages-->
 
-[**Visit our status website →**](https://canonical-web-and-design.github.io)
+[**Visit our status website →**](https://canonical-web-and-design.github.io/upptime)
 
 ## 📄 License
 


### PR DESCRIPTION
Fixes broken link in README.

Not sure if it should be manually changed, or is it generated?